### PR TITLE
Adding a friendly thread queue to make exception event handling async

### DIFF
--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -14,6 +14,7 @@ require 'raven/processor'
 require 'raven/processor/sanitizedata'
 require 'raven/processor/removecircularreferences'
 require 'raven/processor/utf8conversion'
+require 'raven/friendly_thread_queue'
 
 major, minor, patch = RUBY_VERSION.split('.').map(&:to_i)
 if (major == 1 && minor < 9) || (major == 1 && minor == 9 && patch < 2)

--- a/lib/raven/friendly_thread_queue.rb
+++ b/lib/raven/friendly_thread_queue.rb
@@ -1,0 +1,98 @@
+# Copied from Regulator which in turn, copied from Web
+#
+# This class allows messages to be sent to Sentry asynchronously.  Whenever
+# a call to `capture_exception` or `capture_message` is made, the parameters are
+# wrapped in an event object which is then given to the `push` method below.
+#
+# This `push` method adds the event to a queue and returns immediately.
+# Meanwhile, a background thread continously polls from this queue and sends
+# messages to Sentry as it see's them queue up.
+module Raven
+  class FriendlyThreadQueue
+    MAX_QUEUE_SIZE = 100
+    SHUTDOWN_WAIT_RETRIES = 100
+    SHUTDOWN_SLEEP_SEC = 0.05
+
+    def self.push(event)
+      @exception_queue << event
+
+      start_exception_thread! unless @exception_thread.alive?
+      flush_exception_queue if @exception_queue.length > MAX_QUEUE_SIZE
+    end
+
+    def self.start_background_thread!
+      @exception_queue ||= Queue.new
+      @exception_thread_mutex ||= Mutex.new
+
+      start_exception_thread!
+    end
+
+    def self.shutdown_background_thread!
+      if @exception_thread.alive?
+        # wait 5 seconds for the exception_queue to clear
+        SHUTDOWN_WAIT_RETRIES.times do
+          break if @exception_thread.stop? && @exception_queue.empty?
+          sleep SHUTDOWN_SLEEP_SEC
+        end
+        @exception_thread.kill.join
+      end
+      flush_exception_queue
+    end
+
+    if defined?(::Rails) && ::Rails.env.test?
+      def self.wait_for_queue_to_clear
+        # sleep for a moment to wait for the exception to get queued
+        sleep 0.01
+        expire = Time.current + 5.seconds
+        sleep 0.01 until @exception_queue.empty? || Time.current > expire
+        # sleep for another moment to wait for the exception to be "processed"
+        sleep 0.01
+      end
+
+      def self.clear_queue!
+        @exception_queue.clear
+      end
+    end
+
+    def self.start_exception_thread!
+      @exception_thread_mutex.synchronize do
+        return if @exception_thread && @exception_thread.alive?
+
+        @exception_thread = Thread.new do
+          Raven.logger.info('starting background thread')
+          loop do
+            begin
+              if defined?(::METRICS)
+                ::METRICS.multi_gauge('sentry_exception_notifier_queue_size', @exception_queue.size)
+                exception = @exception_queue.pop
+                ::METRICS.time('rpc.sentry.response_time') do
+                  Raven.send_event(exception)
+                end
+              else
+                Raven.send_event(@exception_queue.pop)
+              end
+            rescue StandardError => e
+              Raven.logger.warn("rescued error=#{e.inspect} backtrace=#{e.backtrace.inspect}")
+            rescue Exception => e # rubocop:disable Lint/RescueException
+              Raven.logger.warn("re-raising error=#{e.inspect} backtrace=#{e.backtrace.inspect}")
+              raise
+            end
+          end
+        end
+      end
+    end
+
+    def self.flush_exception_queue
+      return if @exception_queue.empty?
+
+      Raven.logger.warn('flushing queue to log')
+      begin
+        loop do
+          Raven.logger.warn("flush deliver=#{@exception_queue.pop(true).inspect}")
+        end
+      rescue ThreadError
+        Raven.logger.warn('finished flushing queue')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is something we have copied/pasted in our code in almost all repos that use sentry.  It's not specific to Rails or anything, so figured it was worthwhile to have it in the source raven repo.

Usage:

In your raven/sentry initializer file:

``` ruby
Raven.configure do |config|
  ...
  config.async = lambda { |event| Raven::FriendlyThreadQueue.push(event) }
end

Raven::FriendlyThreadQueue.start_background_thread!
at_exit do
  Raven::FriendlyThreadQueue.shutdown_background_thread!
end
```
